### PR TITLE
Update GitHub Pages Deployment to Use GitHub Actions Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,20 +6,36 @@ on:
 jobs:
   latex-document:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v3.0.6
+
       - name: Checkout this repository
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4.0.0
 
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@3.0.1
         with:
           root_file: main.tex
 
       - name: Move and rename document
-        run: mkdir pages && mv main.pdf pages/buku-ta.pdf
+        run: mkdir dist && mv main.pdf dist/buku-ta.pdf
 
-      - name: Deploy document to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2.0.0
         with:
-          branch: gh-pages
-          folder: pages
+          path: dist
+
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.4


### PR DESCRIPTION
This pull request updates the GitHub Pages deployment to utilize the GitHub Actions workflow for deployment instead of relying on a branch, as demonstrated in [GitHub's official documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). 